### PR TITLE
fix: chage format of culumn 'deadline' in seeds.rb

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -37,21 +37,21 @@ Task.create!(
       user_id: 1,
       title: "河川敷10分",
       body: "河川敷ランニング10分",
-      deadline: Time.now,
+      deadline: Time.now.change(sec: 0),
       access_level: 1
     },
     {
       user_id: 2,
       title: "家の掃除",
       body: "洗濯・皿洗い",
-      deadline: Time.now,
+      deadline: Time.now.change(sec: 0),
       access_level: 1
     },
     {
       user_id: 3,
       title: "ハローワークに行く",
       body: "必要書類を提出する",
-      deadline: Time.now,
+      deadline: Time.now.change(sec: 0),
       access_level: 1
     }
   ]


### PR DESCRIPTION
○変更点
▶︎seeds.rbの内容を変更
　▶︎問題点
　・tasksテーブルに保存するdeadlineカラムの値にTime.nowを設定していた
　・タスクに設定する期限（deadline）としては分単位までを想定しており、ja.ymlで分単位までをフォーマットに設定していた
　・db作成時にseeds.rbによって登録されたタスクの期限には、想定していなかった秒単位での値が設定されていた
　▶︎改善
　・seeds.rbに設定するdeadlineの値として、Time.now(sec: 0)を設定した
　・これにより、分単位での設定が可能になった
　