### PR TITLE
feat: Add tags for Google Analytics

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,7 +18,15 @@
     <%= stylesheet_link_tag "application" %>
     <%= display_meta_tags(default_meta_tags) %>
   </head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-Q0KWM953WF"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
 
+    gtag('config', 'G-Q0KWM953WF');
+  </script>
   <body>
     <%= render "shared/flash_message" %>
     <div id="error-messages"></div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,16 +17,17 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
     <%= stylesheet_link_tag "application" %>
     <%= display_meta_tags(default_meta_tags) %>
-  </head>
-  <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-Q0KWM953WF"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-Q0KWM953WF"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-    gtag('config', 'G-Q0KWM953WF');
-  </script>
+      gtag('config', 'G-Q0KWM953WF');
+    </script>
+  </head>
+
   <body>
     <%= render "shared/flash_message" %>
     <div id="error-messages"></div>


### PR DESCRIPTION
# 実施内容
### Google Analyticsの設定
- Google Analytics を有効にするためgtag.jsをhederセクション内に設置しました
- アナリティクスが動作していることを確認しました
- Googl Searvice Consoleが有効になっていることを確認しました
- Google 検索に本サービスが表示されることを確認しました